### PR TITLE
feat: add simple and convinient install.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,3 @@ _testmain.go
 *.exe
 *.test
 *.prof
-install.sh

--- a/README.md
+++ b/README.md
@@ -10,7 +10,14 @@ Conjur provider for [Summon](https://github.com/cyberark/summon).
 
 **Note** Check the release notes and select an appropriate release to ensure support for your version of Conjur.
 
-Download the [latest release](https://github.com/cyberark/summon-conjur/releases) and extract it to the directory `/usr/local/lib/summon`.
+Use the auto-install script. This will install the latest version of summon-conjur.
+The script requires sudo to place summon-conjur in `/usr/local/lib/summon`.
+
+```
+curl -sSL https://raw.githubusercontent.com/cyberark/summon-conjur/master/install.sh | bash
+```
+
+Otherwise, download the [latest release](https://github.com/cyberark/summon-conjur/releases) and extract it to the directory `/usr/local/lib/summon`.
 
 ## Usage in isolation
 

--- a/install.sh
+++ b/install.sh
@@ -45,10 +45,10 @@ URL=${BASEURL}"${LATEST_VERSION}/summon-conjur-${DISTRO}-amd64.tar.gz"
 ZIP_PATH="${tmp_dir}/summon-conjur.tar.gz"
 do_download ${URL} ${ZIP_PATH}
 
-echo "Installing summon v${LATEST_VERSION} into /usr/local/lib/summon"
+echo "Installing summon-conjur ${LATEST_VERSION} into /usr/local/lib/summon"
 
-mkdir -p /usr/local/lib/summon
-tar -C /usr/local/lib/summon -zxvf ${ZIP_PATH}
+sudo mkdir -p /usr/local/lib/summon
+sudo tar -C /usr/local/lib/summon -zxvf ${ZIP_PATH}
 
 echo "Success!"
 echo "Run /usr/local/lib/summon/summon-conjur for usage"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash -e
+
+set -e
+
+ARCH=`uname -m`
+
+if [ "${ARCH}" != "x86_64" ]; then
+  echo "summon-conjur only works on 64-bit systems"
+  echo "exiting installer"
+  exit 1
+fi
+
+DISTRO=`uname | tr "[:upper:]" "[:lower:]"`
+
+if [ "${DISTRO}" != "linux" ] && [ "${DISTRO}" != "darwin"  ]; then
+  echo "This installer only supports Linux and OSX"
+  echo "exiting installer"
+  exit 1
+fi
+
+if test "x$TMPDIR" = "x"; then
+  tmp="/tmp"
+else
+  tmp=$TMPDIR
+fi
+# secure-ish temp dir creation without having mktemp available (DDoS-able but not expliotable)
+tmp_dir="$tmp/install.sh.$$"
+(umask 077 && mkdir $tmp_dir) || exit 1
+
+# do_download URL DIR
+function do_download(){
+  echo "Downloading $1"
+  if   [[ $(type -t wget) ]]; then wget -q -c -O "$2" "$1" >/dev/null
+  elif [[ $(type -t curl) ]]; then curl -sSL -o "$2" "$1"
+  else
+    error "Could not find wget or curl"
+    return 1
+  fi
+}
+
+LATEST_VERSION=$(curl -s https://api.github.com/repos/cyberark/summon-conjur/releases/latest | grep -o '"tag_name": "[^"]*' | grep -o '[^"]*$')
+BASEURL="https://github.com/cyberark/summon-conjur/releases/download/"
+URL=${BASEURL}"${LATEST_VERSION}/summon-conjur-${DISTRO}-amd64.tar.gz"
+
+ZIP_PATH="${tmp_dir}/summon-conjur.tar.gz"
+do_download ${URL} ${ZIP_PATH}
+
+echo "Installing summon v${LATEST_VERSION} into /usr/local/lib/summon"
+
+sudo mkdir -p /usr/local/lib/summon
+sudo tar -C /usr/local/lib/summon -zxvf ${ZIP_PATH}
+
+echo "Success!"
+echo "Run /usr/local/lib/summon/summon-conjur for usage"

--- a/install.sh
+++ b/install.sh
@@ -47,8 +47,8 @@ do_download ${URL} ${ZIP_PATH}
 
 echo "Installing summon v${LATEST_VERSION} into /usr/local/lib/summon"
 
-sudo mkdir -p /usr/local/lib/summon
-sudo tar -C /usr/local/lib/summon -zxvf ${ZIP_PATH}
+mkdir -p /usr/local/lib/summon
+tar -C /usr/local/lib/summon -zxvf ${ZIP_PATH}
 
 echo "Success!"
 echo "Run /usr/local/lib/summon/summon-conjur for usage"


### PR DESCRIPTION
**NOTE** this PR doesn't require/entail a release

## How to verify this PR

+ vet the changes to README.md
+ run the installation script (instead of pointing at `master`, point to this branch `install-sh`) and confirm that `summon-conjur` is successfully installed at `/usr/local/lib/summon`

You can also run this in an environment that has machine identity and try to retrieve a secret while you're at it :)