### PR TITLE
support v5 token format and version flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.5.0
+
+- Support new v5 token format and summon-conjur version flag [pr #23](https://github.com/cyberark/summon-conjur/pull/23).
+
 # v0.4.0
 
 - Support v4, https and configuration from machine identity files, [pr #20](https://github.com/cyberark/summon-conjur/pull/20).

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -9,23 +9,23 @@
 		},
 		{
 			"ImportPath": "github.com/cyberark/conjur-api-go/conjurapi",
-			"Rev": "7bce508a924d514743cb1bf62e8521252e328aef"
+			"Rev": "f238910c7ccbb1c02ae0dd653059043f04680d7b"
 		},
 		{
 			"ImportPath": "github.com/cyberark/conjur-api-go/conjurapi/authn",
-			"Rev": "7bce508a924d514743cb1bf62e8521252e328aef"
+			"Rev": "f238910c7ccbb1c02ae0dd653059043f04680d7b"
 		},
 		{
 			"ImportPath": "github.com/cyberark/conjur-api-go/conjurapi/wrapper",
-			"Rev": "7bce508a924d514743cb1bf62e8521252e328aef"
+			"Rev": "f238910c7ccbb1c02ae0dd653059043f04680d7b"
 		},
 		{
 			"ImportPath": "github.com/cyberark/conjur-api-go/conjurapi/wrapper_v4",
-			"Rev": "7bce508a924d514743cb1bf62e8521252e328aef"
+			"Rev": "f238910c7ccbb1c02ae0dd653059043f04680d7b"
 		},
 		{
 			"ImportPath": "github.com/gopherjs/gopherjs/js",
-			"Rev": "f7c56533adfac99e12ccdccfec04a466d2a778da"
+			"Rev": "444abdf920945de5d4a977b572bcc6c674d1e4eb"
 		},
 		{
 			"ImportPath": "github.com/jtolds/gls",
@@ -34,18 +34,18 @@
 		},
 		{
 			"ImportPath": "github.com/smartystreets/assertions",
-			"Comment": "1.7.0",
-			"Rev": "9c0ea8acbc1d8ad689f9e6fe0c1fa5838e0cabc2"
+			"Comment": "1.8.0-1-g0b37b35",
+			"Rev": "0b37b35ec7434b77e77a4bb29b79677cced992ea"
 		},
 		{
 			"ImportPath": "github.com/smartystreets/assertions/internal/go-render/render",
-			"Comment": "1.7.0",
-			"Rev": "9c0ea8acbc1d8ad689f9e6fe0c1fa5838e0cabc2"
+			"Comment": "1.8.0-1-g0b37b35",
+			"Rev": "0b37b35ec7434b77e77a4bb29b79677cced992ea"
 		},
 		{
 			"ImportPath": "github.com/smartystreets/assertions/internal/oglematchers",
-			"Comment": "1.7.0",
-			"Rev": "9c0ea8acbc1d8ad689f9e6fe0c1fa5838e0cabc2"
+			"Comment": "1.8.0-1-g0b37b35",
+			"Rev": "0b37b35ec7434b77e77a4bb29b79677cced992ea"
 		},
 		{
 			"ImportPath": "github.com/smartystreets/goconvey/convey",

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ $ summon-conjur prod/aws/iam/user/robot/access_key_id
 8h9psadf89sdahfp98
 ```
 
+### Flags
+
+`summon-conjur` supports a single flag.
+
+* `-v, --version` Output version number and quit
+
 ## Usage as a provider for Summon
 
 [Summon](https://github.com/cyberark/summon/) is a command-line tool that reads a file in secrets.yml format and injects secrets as environment variables into any process. Once the process exits, the secrets are gone.

--- a/main.go
+++ b/main.go
@@ -25,12 +25,17 @@ func RetrieveSecret(variableName string) {
 
 func main() {
 	if len(os.Args) != 2 {
-		os.Stderr.Write([]byte("A variable name must be given as the first and only argument!"))
+		os.Stderr.Write([]byte("A variable name or version flag must be given as the first and only argument!"))
 		os.Exit(-1)
 	}
-	variableName := os.Args[1]
 
-	RetrieveSecret(variableName)
+	singleArgument := os.Args[1]
+	switch singleArgument {
+	case "-v","--version":
+		os.Stdout.Write([]byte(VERSION))
+	default:
+		RetrieveSecret(singleArgument)
+	}
 }
 
 func printAndExit(err error) {

--- a/package_test.go
+++ b/package_test.go
@@ -31,7 +31,7 @@ func WithoutArgs()  {
 
 		Convey("Returns with error", func() {
 			So(err, ShouldNotBeNil)
-			So(stderr.String(), ShouldEqual, "A variable name must be given as the first and only argument!")
+			So(stderr.String(), ShouldEqual, "A variable name or version flag must be given as the first and only argument!")
 		})
 	})
 }

--- a/package_test.go
+++ b/package_test.go
@@ -137,7 +137,7 @@ echo $token
 				stdout, _, err := RunCommand("bash", "-c", getToken)
 
 				So(err, ShouldBeNil)
-				So(stdout.String(), ShouldContainSubstring, "data")
+				So(stdout.String(), ShouldContainSubstring, "signature")
 
 				tokenFile, _ := ioutil.TempFile("", "existent-token-file")
 				tokenFileName := tokenFile.Name()

--- a/test.sh
+++ b/test.sh
@@ -6,7 +6,6 @@ function finish {
   docker-compose down -v
 }
 trap finish EXIT
-finish
 
 function main() {
   startConjur

--- a/test.sh
+++ b/test.sh
@@ -6,6 +6,7 @@ function finish {
   docker-compose down -v
 }
 trap finish EXIT
+finish
 
 function main() {
   startConjur

--- a/vendor/github.com/cyberark/conjur-api-go/LICENSE.md
+++ b/vendor/github.com/cyberark/conjur-api-go/LICENSE.md
@@ -179,7 +179,7 @@ recommend that a file or class name and description of purpose be included on
 the same “printed page” as the copyright notice for easier identification within
 third-party archives.
 
-    Copyright [yyyy] [name of copyright owner]
+    Copyright 2017 CyberArk Software, Inc
     
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/vendor/github.com/cyberark/conjur-api-go/conjurapi/authn/auth_token.go
+++ b/vendor/github.com/cyberark/conjur-api-go/conjurapi/authn/auth_token.go
@@ -1,46 +1,154 @@
 package authn
 
 import (
+	"fmt"
 	"time"
 	"encoding/json"
 	"encoding/base64"
 )
 
-type AuthnToken struct {
+type AuthnToken interface {
+	// Parse from JSON. Required before further usage.
+	FromJSON(data []byte) error
+	// Raw token as obtained from the authentication service.
+	Raw() []byte
+	// Whether the token will expire soon.
+	ShouldRefresh() bool
+}
+
+type AuthnToken4 struct {
+	bytes         []byte
 	Data          string `json:"data"`
-	Timestamp     time.Time
-	Base64encoded string
+	timestamp 	  string `json:"timestamp"`
 	Signature 	  string `json:"signature"`
 	Key       	  string `json:"key"`
+	Timestamp     time.Time
 }
 
-func (t *AuthnToken) UnmarshalJSON(data []byte) error {
-	type Alias AuthnToken
-	var (
-		err error
-		timestamp time.Time
-	)
-	aux := struct {
-		Timestamp string `json:"timestamp"`
-		*Alias
-	}{
-		Alias: (*Alias)(t),
+
+// Sample token
+// {"protected":"eyJhbGciOiJjb25qdXIub3JnL3Nsb3NpbG8vdjIiLCJraWQiOiI5M2VjNTEwODRmZTM3Zjc3M2I1ODhlNTYyYWVjZGMxMSJ9","payload":"eyJzdWIiOiJhZG1pbiIsImlhdCI6MTUxMDc1MzI1OX0=","signature":"raCufKOf7sKzciZInQTphu1mBbLhAdIJM72ChLB4m5wKWxFnNz_7LawQ9iYEI_we1-tdZtTXoopn_T1qoTplR9_Bo3KkpI5Hj3DB7SmBpR3CSRTnnEwkJ0_aJ8bql5Cbst4i4rSftyEmUqX-FDOqJdAztdi9BUJyLfbeKTW9OGg-QJQzPX1ucB7IpvTFCEjMoO8KUxZpbHj-KpwqAMZRooG4ULBkxp5nSfs-LN27JupU58oRgIfaWASaDmA98O2x6o88MFpxK_M0FeFGuDKewNGrRc8lCOtTQ9cULA080M5CSnruCqu1Qd52r72KIOAfyzNIiBCLTkblz2fZyEkdSKQmZ8J3AakxQE2jyHmMT-eXjfsEIzEt-IRPJIirI3Qm"}
+// https://www.conjur.org/reference/cryptography.html
+type AuthnToken5 struct {
+	bytes      []byte
+	Protected  string `json:"protected"`
+	Payload    string `json:"payload"`
+	Signature  string `json:"signature"`
+	iat        time.Time
+	exp        *time.Time
+}
+
+func hasField(fields map[string]string, name string) (hasField bool) {
+	_, hasField = fields[name]
+	return
+}
+
+func NewToken(data[] byte) (token AuthnToken, err error) {
+	fields := make(map[string]string)
+	if err = json.Unmarshal(data, &fields); err != nil {
+		err = fmt.Errorf("Unable to unmarshal token : %s", err)
+		return
 	}
 
-	if err = json.Unmarshal(data, &aux); err != nil {
-		return err
+	if hasField(fields, "protected") && hasField(fields, "payload") && hasField(fields, "signature") {
+		t := &AuthnToken5{}
+		token = t
+	} else if hasField(fields, "data") && hasField(fields, "timestamp") && hasField(fields, "signature") && hasField(fields, "key") {
+		t := &AuthnToken4{}
+		token = t
+	} else {
+		err = fmt.Errorf("Unrecognized token format")
+		return
 	}
+	return
+}
 
-	timestamp, err = time.Parse("2006-01-02 15:04:05 MST", aux.Timestamp)
+func (t *AuthnToken5) FromJSON(data []byte) (err error) {
+	t.bytes = data
+
+	err = json.Unmarshal(data, &t)
 	if err != nil {
-		return err
+		err = fmt.Errorf("Unable to unmarshal v5 access token %s", err)
+		return
 	}
 
-	t.Timestamp = timestamp
-	t.Base64encoded = base64.StdEncoding.EncodeToString(data)
-	return nil
+	// Example: {"sub":"admin","iat":1510753259}
+	payloadFields := make(map[string]interface{})
+	var payloadJSON []byte
+	payloadJSON, err = base64.StdEncoding.DecodeString(t.Payload)
+	if err != nil {
+		err = fmt.Errorf("v5 access token field 'payload' is not valid base64")
+		return
+	}
+	err = json.Unmarshal(payloadJSON, &payloadFields)
+	if err != nil {
+		err = fmt.Errorf("Unable to unmarshal v5 access token field 'payload' : %s", err)
+		return
+	}
+
+	iat_v, ok := payloadFields["iat"]
+	if !ok {
+		err = fmt.Errorf("v5 access token field 'payload' does not contain 'iat'")
+		return
+	}
+	iat_f := iat_v.(float64)
+	// In the absence of exp, the token expires at iat+8 minutes
+	t.iat = time.Unix(int64(iat_f), 0)
+
+	exp_v, ok := payloadFields["exp"]
+	if ok {
+		exp_f := exp_v.(float64)
+		exp := time.Unix(int64(exp_f), 0)
+		t.exp = &exp
+		if t.iat.After(*t.exp) {
+			err = fmt.Errorf("v5 access token expired before it was issued")
+			return
+		}
+	}
+
+	return
 }
 
-func (t *AuthnToken) ValidAtTime(refTime time.Time) bool {
-	return refTime.Before(t.Timestamp.Add(5 * time.Minute))
+func (t *AuthnToken4) FromJSON(data []byte) (err error) {
+	t.bytes = data
+
+	err = json.Unmarshal(data, &t)
+	if err != nil {
+		err = fmt.Errorf("Unable to unmarshal v4 access token %s", err)
+		return
+	}
+
+	t.Timestamp, err = time.Parse("2006-01-02 15:04:05 MST", t.timestamp)
+	if err != nil {
+		err = fmt.Errorf("Unable to parse v4 access token field 'timestamp' %s : %s", t.Timestamp, err)
+		return
+	}
+
+	return
 }
+
+func (t *AuthnToken5) Raw() []byte {
+	return t.bytes
+}
+
+func (t *AuthnToken5) ShouldRefresh() bool {
+	if t.exp != nil {
+		// Expire when the token is 85% expired
+		lifespan := t.exp.Sub(t.iat)
+		duration := float32(lifespan) * 0.85
+		return time.Now().After(t.iat.Add(time.Duration(duration)))
+	} else {
+		// Token expires 8 minutes after issue, by default
+		return time.Now().After(t.iat.Add(5 * time.Minute))
+	}
+}
+
+func (t *AuthnToken4) Raw() []byte {
+	return t.bytes
+}
+
+func (t *AuthnToken4) ShouldRefresh() bool {
+	return t.Timestamp.Add(5 * time.Minute).After(time.Now())
+}
+
+

--- a/vendor/github.com/cyberark/conjur-api-go/conjurapi/authn/token_authenticator.go
+++ b/vendor/github.com/cyberark/conjur-api-go/conjurapi/authn/token_authenticator.go
@@ -1,0 +1,13 @@
+package authn
+
+type TokenAuthenticator struct {
+  Token string `env:"CONJUR_AUTHN_TOKEN"`
+}
+
+func (a *TokenAuthenticator) RefreshToken() ([]byte, error) {
+  return []byte(a.Token), nil
+}
+
+func (a *TokenAuthenticator) NeedsTokenRefresh() bool {
+  return false
+}

--- a/vendor/github.com/cyberark/conjur-api-go/conjurapi/client.go
+++ b/vendor/github.com/cyberark/conjur-api-go/conjurapi/client.go
@@ -35,6 +35,13 @@ func NewClientFromKey(config Config, loginPair authn.LoginPair) (*Client, error)
 	return client, err
 }
 
+func NewClientFromToken(config Config, token string) (*Client, error) {
+	return newClientWithAuthenticator(
+		config,
+		&authn.TokenAuthenticator{token},
+	)
+}
+
 func NewClientFromTokenFile(config Config, tokenFile string) (*Client, error) {
 	return newClientWithAuthenticator(
 		config,
@@ -94,6 +101,20 @@ func NewClientFromEnvironment(config Config) (*Client, error) {
 	}
 
 	return nil, fmt.Errorf("Environment variables and machine identity files satisfying at least one authentication strategy must be present!")
+}
+
+func (c *Client) SubmitRequest(req *http.Request) (resp *http.Response, err error) {
+	err = c.createAuthRequest(req)
+	if err != nil {
+		return
+	}
+
+	resp, err = c.httpClient.Do(req)
+	if err != nil {
+		return
+	}
+
+	return
 }
 
 func newClientWithAuthenticator(config Config, authenticator Authenticator) (*Client, error) {

--- a/vendor/github.com/cyberark/conjur-api-go/conjurapi/policy.go
+++ b/vendor/github.com/cyberark/conjur-api-go/conjurapi/policy.go
@@ -6,18 +6,12 @@ import (
 )
 
 func (c *Client) LoadPolicy(policyIdentifier string, policy io.Reader) ([]byte, error) {
-
 	req, err := wrapper.LoadPolicyRequest(c.config.ApplianceURL, c.config.Account, policyIdentifier, policy)
 	if err != nil {
 		return nil, err
 	}
 
-	err = c.createAuthRequest(req)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.SubmitRequest(req)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/cyberark/conjur-api-go/conjurapi/variable.go
+++ b/vendor/github.com/cyberark/conjur-api-go/conjurapi/variable.go
@@ -22,12 +22,7 @@ func (c *Client) RetrieveSecret(variableIdentifier string) ([]byte, error) {
 		return nil, err
 	}
 
-	err = c.createAuthRequest(req)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.SubmitRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -39,20 +34,15 @@ func (c *Client) RetrieveSecret(variableIdentifier string) ([]byte, error) {
 	}
 }
 
-func (c *Client) AddSecret(variableIdentifier string, secretValue string) ([]byte, error) {
+func (c *Client) AddSecret(variableIdentifier string, secretValue string) error {
 	req, err := wrapper.AddSecretRequest(c.config.ApplianceURL, c.config.Account, variableIdentifier, secretValue)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	err = c.createAuthRequest(req)
+	resp, err := c.SubmitRequest(req)
 	if err != nil {
-		return nil, err
-	}
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, err
+		return err
 	}
 
 	return wrapper.AddSecretResponse(variableIdentifier, resp)

--- a/vendor/github.com/cyberark/conjur-api-go/conjurapi/wrapper/variable.go
+++ b/vendor/github.com/cyberark/conjur-api-go/conjurapi/wrapper/variable.go
@@ -24,23 +24,27 @@ func AddSecretRequest(applianceURL, account, variableIdentifier, secretValue str
 }
 
 func RetrieveSecretResponse(variableIdentifier string, resp *http.Response) ([]byte, error) {
+	err := VariableResponse(variableIdentifier, resp)
+	if err != nil {
+		return nil, err
+	}
+	return ByteResponseTransformer(resp)
+}
+
+func AddSecretResponse(variableIdentifier string, resp *http.Response) error {
 	return VariableResponse(variableIdentifier, resp)
 }
 
-func AddSecretResponse(variableIdentifier string, resp *http.Response) ([]byte, error) {
-	return VariableResponse(variableIdentifier, resp)
-}
-
-func VariableResponse(variableIdentifier string, resp *http.Response) ([]byte, error) {
+func VariableResponse(variableIdentifier string, resp *http.Response) error {
 	switch resp.StatusCode {
 	case 404:
-		return nil, fmt.Errorf("%v: Variable '%s' not found", resp.StatusCode, variableIdentifier)
+		return fmt.Errorf("%v: Variable '%s' not found", resp.StatusCode, variableIdentifier)
 	case 403:
-		return nil, fmt.Errorf("%v: Invalid permissions on '%s'", resp.StatusCode, variableIdentifier)
+		return fmt.Errorf("%v: Invalid permissions on '%s'", resp.StatusCode, variableIdentifier)
 	case 200, 201:
-		return ByteResponseTransformer(resp)
+		return nil
 	default:
-		return nil, fmt.Errorf("%v: %s", resp.StatusCode, resp.Status)
+		return fmt.Errorf("%v: %s", resp.StatusCode, resp.Status)
 	}
 }
 

--- a/vendor/github.com/smartystreets/assertions/.travis.yml
+++ b/vendor/github.com/smartystreets/assertions/.travis.yml
@@ -2,11 +2,10 @@ language: go
 
 go:
   - 1.x
-  - master
 
 install:
   - go get -t ./...
 
-script: go test -v
+script: go test ./... -v
 
 sudo: false

--- a/vendor/github.com/smartystreets/assertions/doc.go
+++ b/vendor/github.com/smartystreets/assertions/doc.go
@@ -82,6 +82,8 @@ func (this *Assertion) So(actual interface{}, assert assertion, expected ...inte
 //        log.Println(message)
 //   }
 //
+// For an alternative implementation of So (that provides more flexible return options)
+// see the `So` function in the package at github.com/smartystreets/assertions/assert.
 func So(actual interface{}, assert assertion, expected ...interface{}) (bool, string) {
 	if result := so(actual, assert, expected...); len(result) == 0 {
 		return true, result

--- a/version.go
+++ b/version.go
@@ -1,0 +1,3 @@
+package main
+
+const VERSION = "0.5.0"


### PR DESCRIPTION
addresses https://github.com/cyberark/summon-conjur/issues/22

+ Update the vendored conjur-api-go dependency in summon-conjur.
+ Bump the minor version of summon-conjur.

https://jenkins.conjur.net/job/cyberark--summon-conjur/job/support-v5-token-format/