### PR TITLE
update Jenkinsfile to use the pipeline library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,13 +33,7 @@ pipeline {
 
   post {
     always {
-      sh 'docker run -i --rm -v $PWD:/src -w /src alpine/git clean -fxd'
-    }
-    failure {
-      slackSend(color: 'danger', message: "${env.JOB_NAME} #${env.BUILD_NUMBER} FAILURE (<${env.BUILD_URL}|Open>)")
-    }
-    unstable {
-      slackSend(color: 'warning', message: "${env.JOB_NAME} #${env.BUILD_NUMBER} UNSTABLE (<${env.BUILD_URL}|Open>)")
+      cleanupAndNotify(currentBuild.currentResult)
     }
   }
 }


### PR DESCRIPTION
This update modifies the Jenkinsfile to use [the Jenkins pipeline library](https://github.com/conjurinc/jenkins-pipeline-library/blob/master/vars/cleanupAndNotify.groovy) in the interest of keeping things DRY. This change will also update this repo so that deleteDir will be called at the end of each Jenkins run, as is typical in other repos - we expect this will help with some of the build failures we're currently experiencing.