### PR TITLE
Fix gitlab test invocation path

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,7 @@ build:
 test-unit:
   stage: test
   script:
-    - ./test.sh oss
+    - ./bin/test.sh oss
   artifacts:
     paths:
       - output/junit.xml


### PR DESCRIPTION
Since our test launcher moved, we need to change the invocation path for
GitLab too.