### PR TITLE
Fixed Goreleaser nfpm parameter usage

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,14 +39,14 @@ brews:
       target.install "summon-conjur"
     test: |
       system lib/"summon"/"summon-conjur", "-V"
-  
+
     github:
       owner: cyberark
       name: homebrew-tools
     skip_upload: true
 
 nfpms:
-  - name_template: "{{.ProjectName}}"
+  - file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Arch }}"
     vendor: CyberArk
     homepage: https://github.com/cyberark/summon-conjur
     maintainer: Conjur Maintainers <conj_maintainers@cyberark.com>

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ brew install summon-conjur
 ### Linux (Debian and Red Hat flavors)
 
 `deb` and `rpm` files are attached to new releases.
-These can be installed with `dpkg -i summon-conjur.deb` and
-`rpm -ivh summon-conjur.rpm`, respectively.
+These can be installed with `dpkg -i summon-conjur_*.deb` and
+`rpm -ivh summon-conjur_*.rpm`, respectively.
 
 ### Auto Install
 


### PR DESCRIPTION
Old `name_template` is removed and has been replaced by
`file_name_template` so this commit updates it. We also now provide a
version and arch in the deb/rpm name since those are pretty valuable
pieces of info for an operator.

Fixes #52 