### PR TITLE
Add ability to produce Solaris binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,8 +11,9 @@ builds:
   - CGO_ENABLED=0
   goos:
   - darwin  # MacOS
-  - windows
   - linux
+  - solaris
+  - windows
   goarch:
   - amd64
   ldflags: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Preliminary support for building Solaris binaries.
+  [cyberark/summon-conjur#67](https://github.com/cyberark/summon-conjur/issues/67)
+
 ## [0.5.3] - 2019-02-06
 ### Changed
 - Go modules are now used for dependency management


### PR DESCRIPTION
We had a request to enable our building of Solaris binaries and we can
do that relatively easily. This commit adds that capability to
Goreleaser.

### What ticket does this PR close?
Connected to #67 
Connected to https://github.com/cyberark/summon/issues/173

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation