### PR TITLE
Add information about `.conjurrc` search location on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Specifically, it loads configuration from:
 
  * `.conjurrc` files, located in the home and current directories, or at the
     path specified by the `CONJURRC` environment variable.
- * Reads `/etc/conjur.conf` as a `.conjurrc` file.
+ * Reads the `.conjurrc` file from `/etc/conjur.conf` on Linux/macOS and `C:\Windows\conjur.conf` on Windows.
  * Environment variables:
    * Version
      * `CONJUR_MAJOR_VERSION` - must be set to `4` in order for summon-conjur to work with Conjur v4.9.


### PR DESCRIPTION
We don't list the system-level location that we use for `.conjurrc` on
Windows platforms. This change adds that information to the README.

### What ticket does this PR close?
Resolves #70

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation