### PR TITLE
Propagate verbose to conjur-api-go logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Preliminary support for building Solaris binaries.
   [cyberark/summon-conjur#67](https://github.com/cyberark/summon-conjur/issues/67)
 
+### Fixed
+- Verbose debug output with the -v flag, silently lost in v0.5.3 due to changes
+  to the logging interface in
+  [conjur-api-go](https://github.com/cyberark/conjur-api-go), is reintroduced.
+  [cyberark/summon-conjur#77](https://github.com/cyberark/summon-conjur/issues/77)
+
 ## [0.5.3] - 2019-02-06
 ### Changed
 - Go modules are now used for dependency management

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/cyberark/conjur-api-go/conjurapi"
+	"github.com/cyberark/conjur-api-go/conjurapi/logging"
 	"github.com/cyberark/summon-conjur/pkg/summon_conjur"
 	"github.com/karrick/golf"
 	log "github.com/sirupsen/logrus"
@@ -57,6 +58,7 @@ func main() {
 	log.SetFormatter(&log.TextFormatter{DisableTimestamp: true, DisableLevelTruncation: true})
 	if *verbose {
 		log.SetLevel(log.DebugLevel)
+		logging.ApiLog.SetLevel(log.DebugLevel)
 	}
 
 	RetrieveSecret(args[0])


### PR DESCRIPTION


### What does this PR do?

conjur-api-go has changed its logger interface. The code is updated to use the new interface to pass the verbose flag through to the conjur-api-go logger.

### What ticket does this PR close?
Resolves #77 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation