### PR TITLE
Remove unnecessary globs from .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -70,7 +70,3 @@ release:
     - glob: NOTICES.txt
     - glob: LICENSE
     - glob: CHANGELOG.md
-    - glob: dist/goreleaser/summon-conjur-linux-amd64
-    - glob: dist/goreleaser/summon-conjur-darwin-amd64
-    - glob: dist/goreleaser/summon-conjur-windows-amd64
-    - glob: dist/goreleaser/summon-conjur-solaris-amd64


### PR DESCRIPTION
### What does this PR do?

Remove unnecessary globs from .goreleaser.yml. 
1. They were the wrong globs so were causing failures
2. They would only make sense if we wanted to release raw binaries. Not the case for summon-conjur

### What ticket does this PR close?
Resolves -

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation