### PR TITLE
Fix missing 'v' prefix in Goreleaser brew url_template

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,7 +34,7 @@ checksum:
 brews:
   - description: Conjur provider for Summon
     homepage: https://github.com/cyberark/summon-conjur
-    url_template: https://github.com/cyberark/summon-conjur/releases/download/{{.Version}}/summon-conjur-darwin-amd64.tar.gz
+    url_template: https://github.com/cyberark/summon-conjur/releases/download/v{{.Version}}/summon-conjur-darwin-amd64.tar.gz
     install: |
       target = lib/"summon"
       target.install "summon-conjur"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,7 +34,7 @@ checksum:
 brews:
   - description: Conjur provider for Summon
     homepage: https://github.com/cyberark/summon-conjur
-    url_template: https://github.com/cyberark/summon-conjur/releases/download/v{{.Version}}/summon-conjur-darwin-amd64.tar.gz
+    url_template: https://github.com/cyberark/summon-conjur/releases/download/v{{.Version}}/summon-conjur-{{.Os}}-{{.Arch}}.tar.gz
     install: |
       target = lib/"summon"
       target.install "summon-conjur"


### PR DESCRIPTION
### What does this PR do?

Fix missing 'v' prefix in Goreleaser brew url_template. 


*Annoyingly* Go releaser strips the 'v' prefix on releases but not on snapshots. I saw the snapshot brew formula urls were double prefixed and mistakenly removed the 'v' from the brew url_template. See my question/complaint over at https://github.com/goreleaser/goreleaser/discussions/2114.

### What ticket does this PR close?
Resolves https://github.com/cyberark/homebrew-tools/issues/26

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation