### PR TITLE
Add new Apple hardware platform

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,18 @@ builds:
   ldflags: []
   main: cmd/main.go
 
+# Apple silicon support
+- id: summon-conjur-arm
+  binary: summon-conjur
+  env:
+  - CGO_ENABLED=0
+  goos:
+  - darwin  # MacOS
+  goarch:
+  - arm64
+  ldflags: []
+  main: ./cmd/main.go
+
 archives:
   - id: summon-conjur-release-archive
     name_template: "{{.ProjectName}}-{{.Os}}-{{.Arch}}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Build for Apple M1 silicon.
+  [cyberark/summon-conjur#88](https://github.com/cyberark/summon-conjur/issues/88)
+
 ## [0.5.5] - 2021-06-01
 ### Security
 - Update golang.org/x/crypto to address CVE-2020-29652.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,7 @@ should be officially marked as a `pre-release` (eg "non-production ready")
    - NOTICES.txt
    - LICENSE
    - summon-conjur-darwin-amd64.tar.gz
+   - summon-conjur-darwin-arm64.tar.gz
    - summon-conjur-linux-amd64.tar.gz
    - summon-conjur-windows-amd64.zip
    - summon-conjur-solaris-amd64.tar.gz


### PR DESCRIPTION
### What does this PR do?

GoReleaser builds Windows, Linux and Darwin-amd64 images but does
not build for the new Apple M1 hardware.
This adds the Darwin-arm64 image.

Testing:
kumbirai@Kumbirais-MacBook-Pro Downloads % file ./summon-conjur
./summon-conjur: Mach-O 64-bit executable arm64
kumbirai@Kumbirais-MacBook-Pro Downloads % ./summon-conjur --help
Usage of summon-conjur:
  -h, --help
	show help (default: false)
  -V, --version
	show version (default: false)
  -v, --verbose
	be verbose (default: false)
kumbirai@Kumbirais-MacBook-Pro Downloads % ./summon-conjur test  
ERROR Failed creating a Conjur client: Must specify an ApplianceURL -- Must specify an Account 
kumbirai@Kumbirais-MacBook-Pro Downloads % file ./terraform-provider-conjur-0.5.0-darwin-arm64/summon-conjur
./terraform-provider-conjur-0.5.0-darwin-arm64/summon-conjur: Mach-O 64-bit executable arm64
kumbirai@Kumbirais-MacBook-Pro Downloads % ./terraform-provider-conjur-0.5.0-darwin-arm64/summon-conjur 
This binary is a plugin. These are not meant to be executed directly.
Please execute the program that consumes these plugins, which will
load any plugins automatically



### What ticket does this PR close?
Resolves #88

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation