### PR TITLE
Remove GoConvey

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,24 +23,13 @@ You can start a docker-compose development environment by running
 $ ./dev.sh
 ```
 
-### Dependency management With dep
-[dep](https://golang.github.io/dep/docs/introduction.html) is being used to manage dependencies.
-
-When you add a new package, or change the version of an existing package, run (in the `dev` container)
-
-```sh
-/go/src/github.com/cyberark/summon-conjur# dep ensure
-```
-
-to update `Gopkg.toml` and `Gopkg.lock`.
-
 ### Running tests
 
 Automated CI pipelines:
 - [.gitlab.ci.yml](.gitlab.ci.yml)
 - [Jenkinsfile](Jenkinsfile)
 
-Run `./test.sh oss` for OSS tests, `./test.sh enterprise` for Enterprise tests.
+Run `./bin/test.sh oss` for OSS tests, `./bin/test.sh enterprise` for Enterprise tests.
 This defaults to both.
 
 ## Releasing

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -10,7 +10,6 @@ RUN apk add --no-cache bash \
                        jq \
                        less && \
     go get -u github.com/jstemmer/go-junit-report && \
-    go get -u github.com/smartystreets/goconvey && \
     go get -u github.com/axw/gocov/gocov && \
     go get -u github.com/AlekSi/gocov-xml && \
     mkdir -p /summon-conjur/output

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -11,7 +11,7 @@ Section 1: Apache License 2.0
 
 Section 2: MIT License
 >>> https://github.com/sirupsen/logrus/tree/v1.3.0
->>> https://github.com/smartystreets/goconvey/tree/v1.6.4
+>>> https://github.com/stretchr/testify
 
 Section 3: BSD 3-clause "New" or "Revised" License
 >>> https://github.com/karrick/golf/tree/v1.1.0
@@ -69,9 +69,11 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
->>> https://github.com/smartystreets/goconvey/tree/v1.6.4 
+>>> https://github.com/stretchr/testify
 
-Copyright (c) 2016 SmartyStreets, LLC
+MIT License
+
+Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -90,10 +92,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-NOTE: Various optional and subordinate components carry their own licensing
-requirements and restrictions.  Use of those components is subject to the terms
-and conditions outlined the respective license of each component.
 
 
 --------------- SECTION 3: BSD 3-clause "New" or "Revised" License ----------

--- a/bin/convey.sh
+++ b/bin/convey.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-goconvey -host 0.0.0.0

--- a/dev.sh
+++ b/dev.sh
@@ -31,7 +31,6 @@ function runDevelopment() {
   docker-compose build --pull dev
 
   docker-compose run -d \
-    --entrypoint 'bash -c ./convey.sh' \
     --service-ports \
     -e CONJUR_V4_AUTHN_API_KEY="$api_key_v4" \
     -e CONJUR_V4_SSL_CERTIFICATE="$ssl_cert_v4" \

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cyberark/conjur-api-go v0.7.1
 	github.com/karrick/golf v1.1.0
 	github.com/sirupsen/logrus v1.3.0
-	github.com/smartystreets/goconvey v1.6.4
+	github.com/stretchr/testify v1.5.1
 	golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f // indirect
 	golang.org/x/term v0.0.0-20210503060354-a79de5458b56 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -41,7 +41,6 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f h1:aZp0e2vLN4MToVqnjNEYEtrEA8RH8U8FN1CU7JgqsPU=
 golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -5,8 +5,9 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 )
 
 func splitEq(s string) (string, string) {
@@ -46,13 +47,13 @@ func RunCommand(name string, arg ...string) (bytes.Buffer, bytes.Buffer, error) 
 	return stdout, stderr, err
 }
 
-func WithoutArgs() {
-	Convey("Given summon-conjur is run with no arguments", func() {
+func WithoutArgs(t *testing.T) {
+	t.Run("Given summon-conjur is run with no arguments", func(t *testing.T) {
 		_, stderr, err := RunCommand(PackageName)
 
-		Convey("Returns with error", func() {
-			So(err, ShouldNotBeNil)
-			So(stderr.String(), ShouldEqual, `Usage of summon-conjur:
+		t.Run("Returns with error", func(t *testing.T) {
+			assert.Error(t, err)
+			assert.Equal(t, stderr.String(), `Usage of summon-conjur:
   -h, --help
 	show help (default: false)
   -V, --version

--- a/test/package_enterprise_test.go
+++ b/test/package_enterprise_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPackageEnterprise(t *testing.T) {
@@ -17,7 +17,7 @@ func TestPackageEnterprise(t *testing.T) {
 
 	Path := os.Getenv("PATH")
 
-	Convey("Given valid V4 appliance configuration", t, func() {
+	t.Run("Given valid V4 appliance configuration", func(t *testing.T) {
 		e := ClearEnv()
 		defer e.RestoreEnv()
 		os.Setenv("PATH", Path)
@@ -28,37 +28,37 @@ func TestPackageEnterprise(t *testing.T) {
 		os.Setenv("CONJUR_AUTHN_LOGIN", Login)
 		os.Setenv("CONJUR_SSL_CERTIFICATE", SSLCert_V4)
 
-		Convey("Given valid APIKey credentials", func() {
+		t.Run("Given valid APIKey credentials", func(t *testing.T) {
 			os.Setenv("CONJUR_AUTHN_API_KEY", APIKey_V4)
 
-			WithoutArgs()
+			WithoutArgs(t)
 
-			Convey("Retrieves existing variable's defined value", func() {
+			t.Run("Retrieves existing variable's defined value", func(t *testing.T) {
 				variableIdentifier := "existent-variable-with-defined-value"
 				secretValue := "existent-variable-defined-value"
 
 				stdout, _, err := RunCommand(PackageName, variableIdentifier)
 
-				So(err, ShouldBeNil)
-				So(stdout.String(), ShouldEqual, secretValue)
+				assert.NoError(t, err)
+				assert.Equal(t, stdout.String(), secretValue)
 			})
 
-			Convey("Returns error on existent-variable-undefined-value", func() {
+			t.Run("Returns error on existent-variable-undefined-value", func(t *testing.T) {
 				variableIdentifier := "existent-variable-with-undefined-value"
 
 				_, stderr, err := RunCommand(PackageName, variableIdentifier)
 
-				So(err, ShouldNotBeNil)
-				So(stderr.String(), ShouldContainSubstring, "Not Found")
+				assert.Error(t, err)
+				assert.Contains(t, stderr.String(), "Not Found")
 			})
 
-			Convey("Returns error on non-existent variable", func() {
+			t.Run("Returns error on non-existent variable", func(t *testing.T) {
 				variableIdentifier := "non-existent-variable"
 
 				_, stderr, err := RunCommand(PackageName, variableIdentifier)
 
-				So(err, ShouldNotBeNil)
-				So(stderr.String(), ShouldContainSubstring, "not found")
+				assert.Error(t, err)
+				assert.Contains(t, stderr.String(), "not found")
 			})
 		})
 	})


### PR DESCRIPTION
### What does this PR do?
- Rewrites test that used GoConvey to use a lightweight assertions library and native golang testing

#### Notes
A helpful find & replace regex for this task was:
Find: `Convey\("(.+)", (t, )*func\(\) \{`
Replace: `t.Run("$1", func(t *testing.T) {`

### What ticket does this PR close?
N/A

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation