### PR TITLE
Fix CI Failures

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,8 +13,9 @@ git fetch --tags  # jenkins does not do this automatically yet
 docker pull "${GORELEASER_IMAGE}"
 docker run --rm -t \
   --env GITHUB_TOKEN \
+  --entrypoint "/sbin/tini" \
   -v "$CURRENT_DIR:$MOUNT_DIR" \
   -w "$MOUNT_DIR" \
-  "${GORELEASER_IMAGE}" --rm-dist "$@"
+  "${GORELEASER_IMAGE}" -- sh -c "/entrypoint.sh --rm-dist $@ && rm ./dist/goreleaser/artifacts.json"
 
 echo "Releases built. Archives can be found in dist/goreleaser"


### PR DESCRIPTION
When Jenkins runs, there is an error
```
[2021-12-27T17:08:41.747Z] Archiving artifacts
Failed to extract /var/lib/jenkins/workspace/k--summon-conjur_fix-ci-failures/transfer of 16 files
```
This is due to a new feature in GoReleaser that creates a new file
```
 dist/goreleaser/artifacts.json
```
This file only has user read/write permissions only (600) and is owned by root and then
Jenkins is unable to copy the file.

The fix is to delete the file when GoReleaser runs as we do not need this file. 


### Desired Outcome

Jenkins should run successfully.

### Implemented Changes

Delete the dist/goreleaser/artifacts.json when GoReleaser runs.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]


### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
